### PR TITLE
Make IMU sketches button-less and start after significant motion

### DIFF
--- a/ArduinoSketches/IMU_Capture/IMU_Capture.ino
+++ b/ArduinoSketches/IMU_Capture/IMU_Capture.ino
@@ -1,35 +1,31 @@
 /*
   IMU Capture
 
-  This example uses the on-board IMU to start reading acceleration and gyroscope 
+  This example uses the on-board IMU to start reading acceleration and gyroscope
   data from on-board IMU and prints it to the Serial Monitor for one second
-  when the button is pressed.
+  when the significant motion is detected.
 
   You can also use the Serial Plotter to graph the data.
 
   The circuit:
   - Arduino Nano 33 BLE or Arduino Nano 33 BLE Sense board.
-  - Button connected to pin 3 and GND.
 
   Created by Don Coleman, Sandeep Mistry
+  Modified by Dominic Pajak, Sandeep Mistry
 
   This example code is in the public domain.
 */
 
 #include <Arduino_LSM9DS1.h>
 
-const int buttonPin = 3;     // the number of the pushbutton pin
+const float accelerationThreshold = 2.5; // threshold of significant in G's
 const int numSamples = 119;
 
-int previousButtonState = HIGH;
 int samplesRead = numSamples;
 
 void setup() {
   Serial.begin(9600);
   while (!Serial);
-
-  // initialize the pushbutton pin as an input with (internal) pullup:
-  pinMode(buttonPin, INPUT_PULLUP);
 
   if (!IMU.begin()) {
     Serial.println("Failed to initialize IMU!");
@@ -41,33 +37,32 @@ void setup() {
 }
 
 void loop() {
-  // read the state of the push button pin:
-  int buttonState = digitalRead(buttonPin);
+  float aX, aY, aZ, gX, gY, gZ;
 
-  // compare the button state to the previous state
-  // to see if it has changed
-  if (buttonState != previousButtonState) {
-    if (buttonState == LOW) {
-      if (samplesRead == numSamples) {
-        // pressed
+  // wait for significant motion
+  while (samplesRead == numSamples) {
+    if (IMU.accelerationAvailable()) {
+      // read the acceleration data
+      IMU.readAcceleration(aX, aY, aZ);
+
+      // sum up the absolutes
+      float aSum = fabs(aX) + fabs(aY) + fabs(aZ);
+
+      // check if it's above the threshold
+      if (aSum >= accelerationThreshold) {
+        // reset the sample read count
         samplesRead = 0;
+        break;
       }
-    } else {
-      // released
     }
-
-    // store the state as the previous state, for the next loop
-    previousButtonState = buttonState;
   }
 
-  // check if the all the required samples have been read since 
-  // the last time the button has been pressed
-  if (samplesRead < numSamples) {
+  // check if the all the required samples have been read since
+  // the last time the significant motion was detected
+  while (samplesRead < numSamples) {
     // check if both new acceleration and gyroscope data is
     // available
     if (IMU.accelerationAvailable() && IMU.gyroscopeAvailable()) {
-      float aX, aY, aZ, gX, gY, gZ;
-
       // read the acceleration and gyroscope data
       IMU.readAcceleration(aX, aY, aZ);
       IMU.readGyroscope(gX, gY, gZ);


### PR DESCRIPTION
If this is fine, we can remove the following:

- exercise 2?
- [HardwareTest.ino](https://github.com/arduino/ArduinoTensorFlowLiteTutorials/blob/master/ArduinoSketches/HardwareTest/HardwareTest.ino)

I'm not sure what to do about the [Emoji_Button.ino ](https://github.com/arduino/ArduinoTensorFlowLiteTutorials/blob/master/ArduinoSketches/Emoji_Button/Emoji_Button.ino) example, maybe leave it as is?