### PR TITLE
Align tensorArena in IMU_Classifier to 16 bytes

### DIFF
--- a/GestureToEmoji/ArduinoSketches/IMU_Classifier/IMU_Classifier.ino
+++ b/GestureToEmoji/ArduinoSketches/IMU_Classifier/IMU_Classifier.ino
@@ -50,7 +50,7 @@ TfLiteTensor* tflOutputTensor = nullptr;
 // Create a static memory buffer for TFLM, the size may need to
 // be adjusted based on the model you are using
 constexpr int tensorArenaSize = 8 * 1024;
-byte tensorArena[tensorArenaSize];
+byte tensorArena[tensorArenaSize] __attribute__((aligned(16)));
 
 // array to map gesture index to a name
 const char* GESTURES[] = {


### PR DESCRIPTION
The TensorFlowLite library checks that the supplied arena memory
is aligned to 16 bytes, and crashes if it is not.  This change
ensures the memory is aligned as expected.

There's a pull request already waiting, but it seems to be a more comprehensive (and more complicated!) fix.  This might be a more simple way to get things working for now.