### PR TITLE
Add "smoke test" sketch compilation CI workflow

### DIFF
--- a/.github/workflows/compile-sketches.yml
+++ b/.github/workflows/compile-sketches.yml
@@ -1,0 +1,28 @@
+name: Compile Sketches
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  compile-sketches:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # See: https://github.com/arduino/compile-sketches#readme
+      - name: Compile sketches
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: arduino:mbed:nano33ble
+          sketch-paths: |
+            - FruitToEmoji/sketches/object_color_capture
+            - GestureToEmoji/ArduinoSketches/HardwareTest
+            - GestureToEmoji/ArduinoSketches/IMU_Capture
+            - GestureToEmoji/ArduinoSketches/IMU_Classifier
+          libraries: |
+            - name: Arduino_TensorFlowLite
+            - name: Arduino_APDS9960
+            - name: Arduino_LSM9DS1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Machine Learning on Arduino
 ## Arduino TensorFlow Lite Tutorials
 
+[![Compile Sketches status](https://github.com/arduino/ArduinoTensorFlowLiteTutorials/actions/workflows/compile-sketches.yml/badge.svg)](https://github.com/arduino/ArduinoTensorFlowLiteTutorials/actions/workflows/compile-sketches.yml)
+
 This Github repo contains tutorials for using TensorFlow Lite on Arduino hardware.
 
 * [GestureToEmoji](GestureToEmoji/)


### PR DESCRIPTION
On every push and pull request, compile relevant sketches for the Nano 33 BLE board.